### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://etgigrup.visualstudio.com/0df8ddf5-bbd0-4113-b6ad-8d055ce4ecde/03819d27-1b0e-4942-8453-5aef9b042863/_apis/work/boardbadge/d32d0403-a93c-4ffa-b413-561f385342b8)](https://etgigrup.visualstudio.com/0df8ddf5-bbd0-4113-b6ad-8d055ce4ecde/_boards/board/t/03819d27-1b0e-4942-8453-5aef9b042863/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1040](https://etgigrup.visualstudio.com/0df8ddf5-bbd0-4113-b6ad-8d055ce4ecde/_workitems/edit/1040). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.